### PR TITLE
Implement SharePoint news poster skeleton

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,4 @@
+TENANT_ID=your-tenant-id
+CLIENT_ID=your-client-id
+CLIENT_SECRET=your-secret
+SITE_ID=your-site-id

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,18 @@
+name: CI
+
+on: [push, pull_request]
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-python@v4
+        with:
+          python-version: '3.11'
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r requirements.txt
+      - name: Run tests
+        run: pytest -v

--- a/README.md
+++ b/README.md
@@ -1,1 +1,18 @@
 # sharepoint-pusher
+
+Utilities to create and publish SharePoint news pages using the Microsoft Graph API.
+
+## Setup
+
+```bash
+python -m venv .venv && source .venv/bin/activate
+pip install -r requirements.txt
+```
+
+Copy `.env.example` to `.env` and fill in your credentials.
+
+## Usage
+
+```bash
+python -m news_poster.cli "My Title" "<p>content</p>"
+```

--- a/news_poster/__init__.py
+++ b/news_poster/__init__.py
@@ -1,0 +1,3 @@
+"""Utilities for posting News pages to SharePoint."""
+
+__all__ = ["auth", "sharepoint", "models", "config"]

--- a/news_poster/auth.py
+++ b/news_poster/auth.py
@@ -1,0 +1,24 @@
+"""Authentication helper using MSAL."""
+
+from __future__ import annotations
+
+import os
+from typing import Optional
+
+from msal import ConfidentialClientApplication
+
+from .config import get_config
+
+
+def get_token(scope: str = "https://graph.microsoft.com/.default") -> str:
+    """Acquire an access token for Microsoft Graph."""
+    cfg = get_config()
+    app = ConfidentialClientApplication(
+        client_id=cfg.CLIENT_ID,
+        authority=f"https://login.microsoftonline.com/{cfg.TENANT_ID}",
+        client_credential=cfg.CLIENT_SECRET,
+    )
+    result: Optional[dict] = app.acquire_token_for_client(scopes=[scope])
+    if not result or "access_token" not in result:
+        raise RuntimeError("Failed to obtain access token")
+    return str(result["access_token"])

--- a/news_poster/cli.py
+++ b/news_poster/cli.py
@@ -1,0 +1,24 @@
+"""Command line interface for creating SharePoint news."""
+
+from __future__ import annotations
+
+import argparse
+
+from .models import Article
+from .sharepoint import create_news, publish_page
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Publish news to SharePoint")
+    parser.add_argument("title", help="Title of the article")
+    parser.add_argument("html", help="HTML content of the article")
+    args = parser.parse_args()
+
+    article = Article(title=args.title, html=args.html)
+    page_id = create_news(article.title, article.html)
+    publish_page(page_id)
+    print(f"Published page with id {page_id}")
+
+
+if __name__ == "__main__":
+    main()

--- a/news_poster/config.py
+++ b/news_poster/config.py
@@ -1,0 +1,27 @@
+"""Configuration loading using environment variables."""
+
+from __future__ import annotations
+
+import os
+from dataclasses import dataclass
+
+from dotenv import load_dotenv
+
+load_dotenv()
+
+
+@dataclass
+class Config:
+    TENANT_ID: str
+    CLIENT_ID: str
+    CLIENT_SECRET: str
+    SITE_ID: str
+
+
+def get_config() -> Config:
+    return Config(
+        TENANT_ID=os.environ.get("TENANT_ID", ""),
+        CLIENT_ID=os.environ.get("CLIENT_ID", ""),
+        CLIENT_SECRET=os.environ.get("CLIENT_SECRET", ""),
+        SITE_ID=os.environ.get("SITE_ID", ""),
+    )

--- a/news_poster/models.py
+++ b/news_poster/models.py
@@ -1,0 +1,14 @@
+"""Data models for SharePoint news."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+
+@dataclass
+class Article:
+    """Representation of a SharePoint news article."""
+
+    title: str
+    html: str
+    banner_image_url: str | None = None

--- a/news_poster/sharepoint.py
+++ b/news_poster/sharepoint.py
@@ -1,0 +1,42 @@
+"""Wrapper around Microsoft Graph API for SharePoint news."""
+
+from __future__ import annotations
+
+import os
+from typing import Dict, Any
+
+import requests
+
+from .auth import get_token
+from .config import get_config
+
+GRAPH_ROOT = "https://graph.microsoft.com/v1.0"
+
+
+def _headers() -> Dict[str, str]:
+    token = get_token()
+    return {"Authorization": f"Bearer {token}", "Content-Type": "application/json"}
+
+
+def create_news(title: str, html: str) -> str:
+    """Create a news page and return its page ID."""
+    cfg = get_config()
+    payload = {
+        "title": title,
+        "pageLayout": "Article",
+        "promotionKind": "newsPost",
+        "webParts": [{"type": "rte", "innerHtml": html}],
+    }
+    resp = requests.post(
+        f"{GRAPH_ROOT}/sites/{cfg.SITE_ID}/pages", headers=_headers(), json=payload
+    )
+    resp.raise_for_status()
+    data = resp.json()
+    return data["id"]
+
+
+def publish_page(page_id: str) -> None:
+    cfg = get_config()
+    url = f"{GRAPH_ROOT}/sites/{cfg.SITE_ID}/pages/{page_id}/microsoft.graph.sitePage/publish"
+    resp = requests.post(url, headers=_headers())
+    resp.raise_for_status()

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,6 @@
+msal
+requests
+python-dotenv
+rich
+pytest
+responses

--- a/tests/test_sharepoint.py
+++ b/tests/test_sharepoint.py
@@ -1,0 +1,33 @@
+from __future__ import annotations
+
+import os
+
+import responses
+from news_poster.sharepoint import create_news, publish_page, GRAPH_ROOT
+from news_poster import config
+
+
+@responses.activate
+def test_create_and_publish(monkeypatch):
+    cfg = config.Config(
+        TENANT_ID="tenant",
+        CLIENT_ID="client",
+        CLIENT_SECRET="secret",
+        SITE_ID="site",
+    )
+    monkeypatch.setattr(config, "get_config", lambda: cfg)
+    monkeypatch.setattr("news_poster.auth.get_token", lambda scope="": "token")
+
+    responses.post(
+        f"{GRAPH_ROOT}/sites/{cfg.SITE_ID}/pages",
+        json={"id": "123"},
+        status=201,
+    )
+    responses.post(
+        f"{GRAPH_ROOT}/sites/{cfg.SITE_ID}/pages/123/microsoft.graph.sitePage/publish",
+        status=200,
+    )
+
+    page_id = create_news("title", "<p>body</p>")
+    assert page_id == "123"
+    publish_page(page_id)


### PR DESCRIPTION
## Summary
- add package `news_poster` with modules for auth, SharePoint API helpers, CLI, config and models
- provide basic unit test using responses
- document usage and environment variables
- add GitHub Actions workflow for tests
- include example `.env`

## Testing
- `pip install -r requirements.txt` *(fails: Could not find a version that satisfies the requirement msal)*
- `pytest -q` *(fails: command not found)*


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Introduced a command-line tool to create and publish SharePoint news pages via the Microsoft Graph API.
  - Added support for authentication and configuration through environment variables.
  - Provided a template for environment variable setup.

- **Documentation**
  - Expanded the README with setup and usage instructions for the tool.

- **Tests**
  - Added tests to verify the creation and publishing of SharePoint news pages.

- **Chores**
  - Added dependency and configuration files for setup and continuous integration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->