### PR TITLE
Switch project setup to uv

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,9 +10,11 @@ jobs:
       - uses: actions/setup-python@v4
         with:
           python-version: '3.11'
-      - name: Install dependencies
+      - name: Install uv
+        run: python -m pip install --upgrade uv
+      - name: Set up environment
         run: |
-          python -m pip install --upgrade pip
-          pip install -r requirements.txt
+          uv venv .venv
+          uv pip install -r requirements.txt --python .venv/bin/python
       - name: Run tests
-        run: pytest -v
+        run: .venv/bin/uv -m pytest -v

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,6 @@
+# Ignore Python virtual environments
+.venv/
+__pycache__/
+*.py[cod]
+*.egg-info/
+

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,13 @@
+VENV=.venv
+
+setup:
+uv venv $(VENV)
+uv pip install -r requirements.txt --python $(VENV)/bin/python
+
+run:
+$(VENV)/bin/uv -m news_poster.cli $(ARGS)
+
+test:
+$(VENV)/bin/uv -m pytest -v
+
+.PHONY: setup run test

--- a/README.md
+++ b/README.md
@@ -5,8 +5,8 @@ Utilities to create and publish SharePoint news pages using the Microsoft Graph 
 ## Setup
 
 ```bash
-python -m venv .venv && source .venv/bin/activate
-pip install -r requirements.txt
+uv venv .venv
+uv pip install -r requirements.txt --python .venv/bin/python
 ```
 
 Copy `.env.example` to `.env` and fill in your credentials.
@@ -14,5 +14,5 @@ Copy `.env.example` to `.env` and fill in your credentials.
 ## Usage
 
 ```bash
-python -m news_poster.cli "My Title" "<p>content</p>"
+uv -m news_poster.cli "My Title" "<p>content</p>"
 ```


### PR DESCRIPTION
## Summary
- create `.gitignore` with common Python patterns
- add a `Makefile` with uv-based commands
- document uv usage in README
- update CI workflow to use uv for setup and tests

## Testing
- `uv venv .venv`
- `uv pip install -r requirements.txt --python .venv/bin/python` *(fails: No route to host)*
- `.venv/bin/uv -m pytest -v` *(fails: No such file or directory)*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Updated continuous integration workflow to use the "uv" tool for environment setup and test execution.
	- Added a .gitignore file to exclude common Python environment and build artifacts from version control.
	- Introduced a Makefile to simplify environment setup, running, and testing tasks.

- **Documentation**
	- Updated setup and usage instructions in the README to reflect the use of "uv" for environment management and command execution.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->